### PR TITLE
Add workflow for Close without merging tag

### DIFF
--- a/.github/workflows/close-without-merge-on-label.yml
+++ b/.github/workflows/close-without-merge-on-label.yml
@@ -1,0 +1,31 @@
+name: Close PR on Label
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  close_pr:
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'Close without merging'
+    steps:
+      - name: Close PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            if (pr.state === 'open') {
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                state: 'closed'
+              });
+              console.log('PR closed!');
+            } else {
+              console.log('PR already closed');
+            }


### PR DESCRIPTION
## Practice

Short description

This PR adds a worflow for close without merging label


### Testing Notes if any

Add the close without merging label to check whether it closes or not.
Then reopen it and add auto merge label
